### PR TITLE
Use host networking to access services on the host or in service containers

### DIFF
--- a/phpunit-action.bash
+++ b/phpunit-action.bash
@@ -90,5 +90,6 @@ docker run --rm \
 	--volume "${github_action_path}/phpunit.phar":/usr/local/bin/phpunit \
 	--volume "${GITHUB_WORKSPACE}":/app \
 	--workdir /app \
+	--network host \
 	--env-file <( env| cut -f1 -d= ) \
 	${docker_tag} "${command_string[@]}"


### PR DESCRIPTION
This PR adds a `--network host` argument to the `docker run` command that executes PHPUnit within its own container. This way, the container is not bound to the default bridge network (where it is in practice isolated from other containers and the host system in terms of networking) but instead stays on the host network. It can access services running on the host (e.g. a MySQL daemon). If service containers are used, they can also be accessed as long as their ports are exposed to the host machine using a `ports` declaration.

See #28 for some background.

I've tested this using my own fork [osma/phpunit](https://github.com/osma/phpunit) and it works in my case (accessing a Fuseki service on the host machine). If you want to try it out you can use it like this:

```yaml
    - name: Run PHPUnit tests
      uses: osma/phpunit@v2-network-host
```

Fixes #28
Fixes #26 (probably)