### PR TITLE
Fix default value of memory_limit in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The following configuration options are available:
 + `php_extensions` Space-separated list of extensions using [php-build][php-build] e.g. `xdebug mbstring` (default: N/A)
 + `configuration` Path to the `phpunit.xml` file (default: `test/phpunit/phpunit.xml`)
 + `log_junit` Path to junit output file (default: `test/phpunit/_junit/junit.xml`)
-+ `memory_limit` The memory limit to run your tests with (default: `512M`)
++ `memory_limit` The memory limit to run your tests with (default: `128M`)
 + `bootstrap` The path to the bootstrap file (default: `vendor/autoload.php`)
 
 The syntax for passing in a custom input is the following:


### PR DESCRIPTION
I'm using php-actions/phpunit without setting a `memory_limit`. When I enabled the `pcov` extension to collect code coverage information (which uses more memory than before), my tests started failing with errors like this:

```
Time: 3.22 minutes, Memory: 20.00 MB

There were 3 errors:

1) ConceptSearchParametersTest::testGetVocabids
PHPUnit\Framework\Exception: Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 65536 bytes) in /app/vendor/easyrdf/easyrdf/lib/Parser/Turtle.php on line 1186

2) ConceptSearchParametersTest::testGetSearchTerm
PHPUnit\Framework\Exception: Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 65536 bytes) in /app/vendor/easyrdf/easyrdf/lib/RdfNamespace.php on line 423

3) ConceptSearchParametersTest::testGetSearchLang
PHPUnit\Framework\Exception: Fatal error: Allowed memory size of 134217728 bytes exhausted (tried to allocate 65536 bytes) in /app/vendor/easyrdf/easyrdf/lib/Graph.php on line 556
```

The current README.md states that the default `memory_limit` is 512M but this doesn't seem to be the case, as the actual memory limit is 128M according to the above error messages. There is no default value for the memory_limit setting in [action.yml](https://github.com/php-actions/phpunit/blob/master/action.yml#L43) so I guess that the default value comes from PHP itself. Setting memory_limit to 512M fixed the problem with my tests.

This PR changes the README to state the correct default value for memory_limit. An alternative would be to set a default value of 512M in action.yml, so that reality would then correspond to the documentation.