### PR TITLE
support --coverage-filter flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ The following configuration options are available:
 + `group` Only runs tests from the specified group(s)
 + `exclude_group` Exclude tests from the specified group(s)
 + `test_suffix` Only search for test in files with specified suffix(es)
-+ `whitelist` Path to directory to whitelist for code coverage analysis
++ `whitelist` Path to directory to whitelist for code coverage analysis (phpunit <= 8)
++ `coverage_filter` Include directory in code coverage reporting (phpunit >= 9)
 + `coverage_clover` Generate code coverage report in Clover XML format
 + `coverage_cobertura` Generate code coverage report in Cobertura XML format
   required

--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,10 @@ inputs:
     description: Path to directory to whitelist for code coverage analysis
     required: false
 
+  coverage_filter:
+    description: Include directory in code coverage reporting
+    required: false
+
   coverage_clover:
     description: Generate code coverage report in Clover XML format
     required: false
@@ -126,6 +130,7 @@ runs:
         ACTION_TEST_SUFFIX: ${{ inputs.test_suffix }}
         ACTION_WHITELIST: ${{ inputs.whitelist }}
         ACTION_MEMORY_LIMIT: ${{ inputs.memory_limit }}
+        ACTION_COVERAGE_FILTER: ${{ inputs.coverage_filter }}
         ACTION_COVERAGE_CLOVER: ${{ inputs.coverage_clover }}
         ACTION_COVERAGE_COBERTURA: ${{ inputs.coverage_cobertura }}
         ACTION_COVERAGE_CRAP4J: ${{ inputs.coverage_crap4j }}

--- a/phpunit-action.bash
+++ b/phpunit-action.bash
@@ -86,6 +86,12 @@ then
 	command_string+=(-d memory_limit="$ACTION_MEMORY_LIMIT")
 fi
 
+if [ -n "$ACTION_COVERAGE_FILTER" ]
+then
+	command_string+=(--coverage-filter "$ACTION_COVERAGE_FILTER")
+	export XDEBUG_MODE=coverage
+fi
+
 if [ -n "$ACTION_COVERAGE_CLOVER" ]
 then
 	command_string+=(--coverage-clover "$ACTION_COVERAGE_CLOVER")


### PR DESCRIPTION
Since phpunit 9, `--whitelist` got replaced with `--coverage-filter`

Also, since any type of coverage requires a filter, and also requires `XDEBUG_MODE=coverage`, I have made the flag automatically set the environment variable so that users don't need to figure that out for themselves