### PR TITLE
Remove the default value for the test_suffix parameter

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -67,7 +67,6 @@ inputs:
   test_suffix:
     description: Only search for test in files with specified suffix(es)
     required: false
-    default: Test.php,.phpt
 
   whitelist:
     description: Path to directory to whitelist for code coverage analysis


### PR DESCRIPTION
Passing a comma-separated list of values to the CLI argument `--test-suffix` [has been deprecated in PHPUnit 11 and will no longer work in PHPUnit 12](https://github.com/sebastianbergmann/phpunit/issues/5709).  Given that this action is sending [its default value](https://docs.phpunit.de/en/11.1/textui.html#selection) anyways, there's no reason to explicitly provide this command line argument.  Further, it's confusing that this command line argument is specified at all when nothing in my repo's configuration sets its value.