### PR TITLE
make env handling more robust

### DIFF
--- a/phpunit-action.bash
+++ b/phpunit-action.bash
@@ -170,5 +170,5 @@ docker run --rm \
 	--volume "${GITHUB_WORKSPACE}":/app \
 	--workdir /app \
 	--network host \
-	--env-file <( env| cut -f1 -d= ) \
+	--env-file <(env | grep '=' | cut -f1 -d=) \
 	${docker_tag} "${command_string[@]}"


### PR DESCRIPTION
This is a potential fix for https://github.com/php-actions/phpunit/issues/75

It filters the --env-file process to ensure it only passes valid formatted env values